### PR TITLE
Fix runtime checks in fuzzer

### DIFF
--- a/runner/src/bin/fuzzer/main.rs
+++ b/runner/src/bin/fuzzer/main.rs
@@ -192,15 +192,15 @@ fn fuzz_test(
 #[derive(Parser, Debug)]
 struct Args {
     /// Number of concurrent clients.
-    #[arg(short, long, default_value = "1")]
+    #[arg(long, default_value = "1")]
     num_clis: usize,
 
     /// Number of keys touched by each client.
-    #[arg(short, long, default_value = "5")]
+    #[arg(long, default_value = "5")]
     num_keys: usize,
 
     /// Average number of operations per client to run.
-    #[arg(short, long, default_value = "5000")]
+    #[arg(long, default_value = "5000")]
     num_ops: usize,
 
     /// False if use disjoint sets of keys per client, otherwise true.

--- a/runner/src/bin/fuzzer/random.rs
+++ b/runner/src/bin/fuzzer/random.rs
@@ -36,8 +36,8 @@ pub(crate) fn gen_call_vs_wait(ops_called: usize, num_ops: usize, flying: &BitVe
 /// Generate a random client index, retry until one with expected on-the-fly
 /// status is found.
 pub(crate) fn gen_rand_client(flying: &BitVec, want_flying: bool) -> usize {
-    debug_assert!(want_flying || flying.all());
-    debug_assert!(!want_flying || flying.none());
+    debug_assert!(want_flying || !flying.all());
+    debug_assert!(!want_flying || !flying.none());
     loop {
         let cidx = gen_rand_index(flying.len());
         if flying.get(cidx).unwrap() == want_flying {


### PR DESCRIPTION
Two `debug_assert`s in fuzzer contain typos. I also removed the conflicting short command line arguments starting with `num`. 