### PR TITLE
Scripts for running all p2 experiments automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "cfg-if"
@@ -78,9 +72,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -88,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -100,12 +94,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
+ "anstyle",
  "heck",
  "proc-macro2",
+ "pulldown-cmark",
  "quote",
  "syn",
 ]
@@ -144,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,10 +170,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "memchr"
@@ -197,33 +208,44 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.38"
+name = "pulldown-cmark"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -236,7 +258,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha",
  "rand_core",
- "zerocopy 0.8.14",
+ "zerocopy",
 ]
 
 [[package]]
@@ -251,12 +273,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
- "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -270,15 +291,16 @@ dependencies = [
  "bit-vec",
  "clap",
  "color-print",
+ "itertools",
  "rand",
  "strum",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "strsim"
@@ -310,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -320,10 +342,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.15"
+name = "unicase"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -424,39 +452,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
-dependencies = [
- "zerocopy-derive 0.8.14",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -7,7 +7,8 @@ authors = ["Guanzhou Hu <me@josehu.com>"]
 
 [dependencies]
 rand = { workspace = true }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "unstable-markdown"] }
 color-print = "0.3"
 bit-vec = "0.8"
 strum = { version = "0.26", features = ["derive"] }
+itertools = "0.14.0"

--- a/runner/src/bin/run_p2.rs
+++ b/runner/src/bin/run_p2.rs
@@ -1,0 +1,311 @@
+use std::collections::HashSet;
+use std::process::{Child, Command};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::thread;
+use std::time::{Duration, SystemTime};
+
+use clap::Parser;
+use itertools::izip;
+use rand::Rng;
+
+#[derive(Clone)]
+struct Env {
+    username: String,
+    path: String,
+}
+
+fn setup_server(
+    server_id: i32,
+    ip: &str,
+    disk_id: i32,
+    port: i32,
+    manager: &(String, i32),
+    env: &Env,
+) -> Child {
+    let command = format!(
+        r#"
+echo $$ >> /tmp/madkv-run-p2-pids
+cd {5}
+sudo ./scripts/setup_fs.sh {0}
+sudo ./scripts/map_mount.sh {0}
+touch /mnt/madkv-{0}/MADKV_MARKER
+while true; do
+    if [[ -e /mnt/madkv-{0}/MADKV_MARKER ]]; then
+        # still have race conditions
+        # but not likely
+        just p2::server {1} {2}:{3} {4} /mnt/madkv-{0}/log
+    fi
+    sleep 1
+done"#,
+        disk_id, server_id, manager.0, manager.1, port, env.path
+    );
+    Command::new("ssh")
+        .arg(format!("{}@{}", env.username, ip))
+        .arg(command)
+        .spawn()
+        .unwrap()
+}
+
+fn reset_disk(_server_id: i32, ip: &str, disk_id: i32, _port: i32, env: &Env) {
+    let command = format!(
+        r#"
+cd {1}
+sudo ./scripts/crash_map.sh {0}
+sudo ./scripts/map_mount.sh {0}"#,
+        disk_id, env.path
+    );
+    #[allow(clippy::zombie_processes)]
+    let _ = Command::new("ssh")
+        .arg(format!("{}@{}", env.username, ip))
+        .arg(command)
+        .spawn()
+        .unwrap();
+}
+
+fn periodic_reset_disks(servers: &[(String, i32, i32)], stop: Arc<AtomicBool>, env: &Env) {
+    let mut last_crash: Vec<Option<f64>> = vec![None; servers.len()];
+    let mut rng = rand::rng();
+    while !stop.load(Ordering::Relaxed) {
+        let sleep_time = rng.random_range(1.0..2.0);
+        thread::sleep(Duration::from_secs_f64(sleep_time));
+
+        let server_index = rng.random_range(0..servers.len());
+        let (ref ip, disk_id, port) = servers[server_index];
+        let curr_time = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs_f64();
+
+        if last_crash[server_index].is_none_or(|t| t + 5.0 < curr_time) {
+            println!("inject fault on server {}", server_index);
+            last_crash[server_index] = Some(curr_time);
+            reset_disk(server_index as i32, ip, disk_id, port, env);
+        }
+    }
+}
+
+fn run_manager(manager: &(String, i32), servers: &[(String, i32, i32)], env: &Env) {
+    let manager_ip = &manager.0;
+    let manager_port = manager.1;
+    let servers_str: Vec<String> = servers
+        .iter()
+        .map(|(ip, _disk, port)| format!("{}:{}", ip, port))
+        .collect();
+    let servers_str = servers_str.join(",");
+    let command = format!(
+        r#"
+cd {0}
+just p2::manager {manager_port} {servers_str}
+"#,
+        env.path
+    );
+    #[allow(clippy::zombie_processes)]
+    let _ = Command::new("ssh")
+        .arg(format!("{}@{}", env.username, manager_ip))
+        .arg(command)
+        .spawn()
+        .unwrap();
+}
+
+fn kill_all(servers: &[(String, i32, i32)], env: &Env) {
+    let unique_ips: HashSet<&String> = servers.iter().map(|(ip, _, _)| ip).collect();
+    for ip in unique_ips {
+        let command = format!(
+            r#"
+cd {}
+just p2::kill
+if [ -e /tmp/madkv-run-p2-pids ]; then
+    while read -r pid; do
+        if [ -n "$pid" ]; then
+            pkill -P "$pid"
+            kill "$pid"
+        fi
+    done < /tmp/madkv-run-p2-pids
+    rm /tmp/madkv-run-p2-pids
+fi
+"#,
+            env.path
+        );
+        let _ = Command::new("ssh")
+            .arg(format!("{}@{}", env.username, ip))
+            .arg(command)
+            .status()
+            .expect("failed to run kill_all command");
+    }
+}
+
+fn run(
+    cmd: &str,
+    servers: Vec<(String, i32, i32)>,
+    manager: &(String, i32),
+    crash: bool,
+    env: &Env,
+) {
+    kill_all(&servers, env);
+    run_manager(manager, &servers, env);
+
+    let mut server_procs: Vec<Child> = Vec::new();
+    for (server_id, (ip, disk_id, port)) in servers.iter().enumerate() {
+        let child = setup_server(server_id as i32, ip, *disk_id, *port, manager, env);
+        server_procs.push(child);
+    }
+    thread::sleep(Duration::from_secs(5));
+
+    let command = format!(
+        r#"
+cd {}
+just {} {}:{}
+"#,
+        env.path, cmd, manager.0, manager.1
+    );
+    let mut fuzz_proc = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .spawn()
+        .expect("failed to spawn fuzz process");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let crash_handle = if crash {
+        let servers_clone = servers.clone();
+        let stop_clone = Arc::clone(&stop);
+        let env = env.clone();
+        Some(thread::spawn(move || {
+            periodic_reset_disks(&servers_clone, stop_clone, &env);
+        }))
+    } else {
+        None
+    };
+
+    fuzz_proc.wait().expect("failed waiting for fuzz process");
+    kill_all(&servers, env);
+
+    if crash {
+        stop.store(true, Ordering::Relaxed);
+        if let Some(handle) = crash_handle {
+            handle.join().expect("failed to join crash thread");
+        }
+    }
+
+    for mut proc in server_procs {
+        let _ = proc.kill();
+    }
+}
+
+#[derive(Parser, Debug)]
+/// Run all experiments required for Project 2.
+/// Do NOT run the servers on your personal machine unless you know what you're doing!
+/// Use `--help` to see the long help message.
+///
+/// # Setup
+///
+/// This script assumes that you are using one NVME SSD for each server instance.
+/// You can spread those instances across multiple physical machines, but the total number of
+/// instances must be 5.
+/// The manager always runs on the first machine specified.
+/// Make sure you can ssh into all servers with ssh keys.
+///
+/// Before running each experiment, the script sets up a clean ext4 file system with
+/// [fast_commit](https://dl.acm.org/doi/abs/10.5555/3691992.3692002) turned on, which is suitable
+/// for fsync-heavy workloads.
+/// Since this needs root privilege, it assumes you can run `sudo` without a password.
+///
+/// # Fault injection
+///
+/// When running the fuzz tester with crashing servers, the script periodically chooses a server
+/// and simulates a disk disconnection on it. This is achieved via the
+/// [Linux device mapper](https://docs.kernel.org/admin-guide/device-mapper/index.html).
+/// Your server should experience I/O errors and may crash. New server instances will be restarted
+/// once the script sets up the file system again.
+///
+/// # Example
+///
+/// ```bash
+/// cargo run --bin run_p2 -- \
+///     --username ljx --path "~/739madkv/" \
+///     --address 128.105.146.89 \
+///     --num-server 3 \
+///     --disk-id-start 1 \
+///     --address 128.105.146.88 \
+///     --num-server 2 \
+///     --disk-id-start 1
+/// ```
+///
+/// With two Cloudlab sm110p machines, this typically takes around 10 minutes.
+struct Args {
+    #[arg(long)]
+    username: String,
+    #[arg(long)]
+    path: String,
+    #[arg(long, required = true)]
+    /// These three args can be repeated. Matched by the order they appear.
+    address: Vec<String>,
+    #[arg(long, required = true)]
+    /// Number of server instances on this **single** machine.
+    num_server: Vec<i32>,
+    #[arg(long, required = true)]
+    /// The first disk to use for this machine. You might want to skip the ones you use for other
+    /// purposes.
+    /// e.g. if num_server=2, disk_id_start=1 means /dev/nvme1n1 and /dev/nvme2n1 are used.
+    disk_id_start: Vec<i32>,
+}
+
+fn main() {
+    let args = Args::parse();
+    let env = Env {
+        username: args.username,
+        path: args.path,
+    };
+    assert_eq!(args.address.len(), args.num_server.len());
+    assert_eq!(args.address.len(), args.disk_id_start.len());
+    assert_eq!(args.num_server.iter().sum::<i32>(), 5);
+
+    let servers: Vec<(String, i32, i32)> =
+        izip!(&args.address, args.num_server, args.disk_id_start)
+            .map(move |(address, num_server, disk_id_start)| {
+                (disk_id_start..disk_id_start + num_server)
+                    .map(move |i| (address.clone(), i, 3700 + i))
+            })
+            .flatten()
+            .collect();
+    let manager = (args.address.first().unwrap().clone(), 3777);
+
+    let fuzz = |num_server: usize, crash: bool| {
+        let crash_str = if crash { "yes" } else { "no" };
+        run(
+            &format!("p2::fuzz {num_server} {crash_str}"),
+            servers[..num_server].to_vec(),
+            &manager,
+            crash,
+            &env,
+        );
+    };
+
+    let bench = |num_server: usize, num_client: usize, workload: char| {
+        run(
+            &format!("p2::bench {num_client} {workload} {num_server}"),
+            servers[..num_server].to_vec(),
+            &manager,
+            false,
+            &env,
+        );
+    };
+
+    fuzz(3, false);
+    fuzz(3, true);
+    fuzz(5, true);
+
+    for workload in 'a'..='f' {
+        for num_server in [1, 3, 5] {
+            bench(num_server, 10, workload);
+        }
+    }
+
+    for num_client in [1, 20, 30] {
+        for num_server in [1, 5] {
+            bench(num_server, num_client, 'a');
+        }
+    }
+}

--- a/scripts/crash_map.sh
+++ b/scripts/crash_map.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+id="$1"
+mapper_name=madkv-"$id"
+
+dmsetup wipe_table "$mapper_name"

--- a/scripts/map_mount.sh
+++ b/scripts/map_mount.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+id="$1"
+
+mapper_name=madkv-"$id"
+mount_point=/mnt/"$mapper_name"
+dev_path=/dev/nvme"$id"n1
+
+kill $(lsof -t "$mount_point")
+umount "$mount_point"
+dmsetup remove "$mapper_name"
+dmsetup create "$mapper_name" --table "0 $(blockdev --getsz "$dev_path") linear $dev_path 0"
+mkdir -p "$mount_point"
+mount -O data=journal /dev/mapper/"$mapper_name" "$mount_point"
+chmod -R ugoa+rw "$mount_point"

--- a/scripts/setup_fs.sh
+++ b/scripts/setup_fs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash
+
+id="$1"
+dev_path=/dev/nvme"$id"n1
+mapper_name=madkv-"$id"
+mount_point=/mnt/"$mapper_name"
+
+kill $(lsof -t "$mount_point")
+umount "$mount_point"
+dmsetup remove "$mapper_name"
+mkfs.ext4 -F -O fast_commit "$dev_path"


### PR DESCRIPTION
See the help message for more details:
```
cargo run --bin run_p2 -- --help
```

Run all experiments required for Project 2.
Do NOT run the servers on your personal machine unless you know what you're doing!
Use `--help` to see the long help message.
                                                                                             
# Setup
                                                                                             
This script assumes that you are using one NVME SSD for each server instance.
You can spread those instances across multiple physical machines, but the total number of instances must be 5. The manager always runs on the first machine specified. Make sure you can ssh into all servers with ssh keys.
                                                                                             
Before running each experiment, the script sets up a clean ext4 file system with [fast_commit](https://dl.acm.org/doi/abs/10.5555/3691992.3692002) turned on, which is suitable for fsync-heavy workloads. Since this needs root privilege, it assumes you can run `sudo` without a password.
                                                                                             
# Fault injection
                                                                                             
When running the fuzz tester with crashing servers, the script periodically chooses a server and simulates a disk disconnection on it. This is achieved via the [Linux device mapper](https://docs.kernel.org/admin-guide/device-mapper/index.html). Your server should experience I/O errors and may crash. New server instances will be restarted once the script sets up the file system again.
                                                                                             
# Example
                                                                                             
```bash
cargo run --bin run_p2 -- \
    --username ljx --path "~/739madkv/" \
    --address 128.105.146.89 \
    --num-server 3 \
    --disk-id-start 1 \
    --address 128.105.146.88 \
    --num-server 2 \
    --disk-id-start 1
```
                                                                                             
With two cloudlab sm110p machines, this typically takes around 10 minutes.